### PR TITLE
Images resize/cache

### DIFF
--- a/RustRBLootEditor/App.xaml
+++ b/RustRBLootEditor/App.xaml
@@ -8,7 +8,7 @@
         <Converters:CaseConverter x:Key="CaseConverterToLower" Case="Lower"/>
         <Converters:UriFromShortnameConverter x:Key="UriFromShortnameConverter"/>
         <Converters:LocalUriFromShortnameConverter x:Key="LocalUriFromShortnameConverter"/>
-        <Converters:RelativeUriFromShortnameConverter x:Key="RelativeUriFromShortnameConverter"/>
+        <!--<Converters:RelativeUriFromShortnameConverter x:Key="RelativeUriFromShortnameConverter"/>-->
         <Converters:FormatNumberConverter x:Key="FormatNumberConverter"/>
         <Converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
         <Converters:RelativeUriFromLootItemConverter x:Key="RelativeUriFromLootItemConverter"/>

--- a/RustRBLootEditor/Converters/RelativeUriFromShortnameConverter.cs
+++ b/RustRBLootEditor/Converters/RelativeUriFromShortnameConverter.cs
@@ -1,53 +1,65 @@
-﻿using RustRBLootEditor.Helpers;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
-using System.Windows.Data;
+﻿//using RustRBLootEditor.Helpers;
+//using System;
+//using System.Collections.Generic;
+//using System.Globalization;
+//using System.IO;
+//using System.Linq;
+//using System.Reflection;
+//using System.Text;
+//using System.Threading.Tasks;
+//using System.Windows;
+//using System.Windows.Data;
+//using System.Windows.Media.Imaging;
+//using System.Windows.Media;
+//using System.Drawing;
+//using System.Drawing.Imaging;
 
-namespace RustRBLootEditor.Converters
-{
-    public class RelativeUriFromShortnameConverter : IValueConverter
-    {
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            if (value != null)
-            {
-                string partialpath = "";
+//namespace RustRBLootEditor.Converters
+//{
+//    public class RelativeUriFromShortnameConverter : IValueConverter
+//    {
+//        static readonly Dictionary<string, BitmapSource> images = new Dictionary<string, BitmapSource>();
+//        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+//        {
+//            if (value != null)
+//            {
+//                if (!images.TryGetValue(value.ToString(), out var img) && File.Exists($"F:\\Games\\steamapps\\common\\Rust\\Bundles\\items\\{value}.png"))
+//                {
+//                    using FileStream fs = new FileStream($"F:\\Games\\steamapps\\common\\Rust\\Bundles\\items\\{value}.png", FileMode.Open);
+//                    using Image source = new Bitmap(fs);
+//                    using Image destination = new Bitmap(64, 64);
 
-                if (parameter != null && parameter.ToString() != null) { partialpath = parameter.ToString(); }
+//                    using (var g = Graphics.FromImage(destination))
+//                    {
+//                        g.InterpolationMode = System.Drawing.Drawing2D.InterpolationMode.HighQualityBilinear;
+//                        g.DrawImage(source, new Rectangle(0, 0, 64, 64), new Rectangle(0, 0, (int)source.Width, (int)source.Height), GraphicsUnit.Pixel);
+//                    }
+//                    var stream = new MemoryStream();
+//                    destination.Save(stream, ImageFormat.Png);
 
-                string debugpath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-                string imagepath = Path.Combine(debugpath, partialpath, value.ToString());
+//                    var image = new BitmapImage();
+//                    image.BeginInit();
+//                    image.StreamSource = stream;
+//                    image.EndInit();
 
-                if (!imagepath.EndsWith(".png") && !imagepath.EndsWith(".jpg") && !imagepath.EndsWith(".jpeg"))
-                {
-                    imagepath = imagepath + ".png";
-                }
+//                    var i = image.Clone();
+//                    i.Freeze();
 
-                if (File.Exists(imagepath))
-                {
-                    return new Uri(imagepath, UriKind.RelativeOrAbsolute);
-                }
-                else
-                {
-                    return new Uri("/RustRBLootEditor;component/Assets/unavailable.png", UriKind.Relative);
-                }
-            }
-            else
-            {
-                return DependencyProperty.UnsetValue;
-            }
-        }
+//                    images[value.ToString()] = img = i;
+//                }
 
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            throw new NotImplementedException();
-        }
-    }
-}
+//                if (img != null) return img;
+//                return DependencyProperty.UnsetValue;
+//            }
+//            else
+//            {
+//                return DependencyProperty.UnsetValue;
+//            }
+//        }
+
+//        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+//        {
+//            throw new NotImplementedException();
+//        }
+//    }
+//}

--- a/RustRBLootEditor/MainWindow.xaml
+++ b/RustRBLootEditor/MainWindow.xaml
@@ -353,7 +353,7 @@
                             <TextBlock Text="{Binding SelectedEditGameItem.displayName}" FontFamily="Lato Bold" FontSize="16" Margin="0,0,0,10" Foreground="#9bcf3e" TextWrapping="Wrap" />
                             <TextBlock Text="{Binding SelectedEditGameItem.shortName}" FontFamily="Lato Bold" FontSize="16" Margin="0,0,0,10" Foreground="White" TextWrapping="Wrap" />
                         </StackPanel>
-                        <Image Grid.Column="1" Source="{Binding SelectedEditGameItem.shortName, Converter={StaticResource RelativeUriFromShortnameConverter}, ConverterParameter='Assets\\RustItems'}" 
+                        <Image Grid.Column="1" Source="{Binding SelectedEditGameItem.Source}" 
                            Width="75" Height="75"
                            HorizontalAlignment="Right" VerticalAlignment="Top" Margin="0,0,0,10"></Image>
                     </Grid>

--- a/RustRBLootEditor/Models/RustItems.cs
+++ b/RustRBLootEditor/Models/RustItems.cs
@@ -1,15 +1,20 @@
 ﻿using HtmlAgilityPack;
+using Newtonsoft.Json.Linq;
 using Prism.Mvvm;
 using RustRBLootEditor.Helpers;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Drawing.Imaging;
+using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
 
 namespace RustRBLootEditor.Models
 {
@@ -107,6 +112,42 @@ namespace RustRBLootEditor.Models
         {
             get { return _category; }
             set { SetProperty(ref _category, value); }
+        }
+
+        BitmapSource _src = null;
+        static readonly BitmapImage noImage = new BitmapImage(new Uri("/RustRBLootEditor;component/Assets/unavailable.png", UriKind.Relative));
+        public ImageSource Source
+        {
+            get
+            {
+                if (_src is null && File.Exists($"F:\\Games\\steamapps\\common\\Rust\\Bundles\\items\\{shortName}.png"))
+                {
+                    using FileStream fs = new FileStream($"F:\\Games\\steamapps\\common\\Rust\\Bundles\\items\\{shortName}.png", FileMode.Open);
+                    using Image source = new Bitmap(fs);
+                    using Image destination = new Bitmap(64, 64);
+
+                    using (var g = Graphics.FromImage(destination))
+                    {
+                        g.InterpolationMode = System.Drawing.Drawing2D.InterpolationMode.HighQualityBilinear;
+                        g.DrawImage(source, new Rectangle(0, 0, 64, 64), new Rectangle(0, 0, (int)source.Width, (int)source.Height), GraphicsUnit.Pixel);
+                    }
+                    var stream = new MemoryStream();
+                    destination.Save(stream, ImageFormat.Png);
+
+                    var image = new BitmapImage();
+                    image.BeginInit();
+                    image.StreamSource = stream;
+                    image.EndInit();
+
+                    var i = image.Clone();
+                    i.Freeze();
+
+                    _src = i;
+                }
+                else if (_src is null)
+                    _src = noImage;
+                return _src;
+            }
         }
     }
 }

--- a/RustRBLootEditor/RustRBLootEditor.csproj
+++ b/RustRBLootEditor/RustRBLootEditor.csproj
@@ -3305,6 +3305,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Prism.Core" Version="8.1.97" />
     <PackageReference Include="Prism.Wpf" Version="8.1.97" />
+    <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
     <PackageReference Include="System.Resources.ResourceManager" Version="4.3.0" />
     <PackageReference Include="VirtualizingWrapPanel" Version="1.5.7" />
   </ItemGroup>

--- a/RustRBLootEditor/UserControls/RustItemsUC.xaml
+++ b/RustRBLootEditor/UserControls/RustItemsUC.xaml
@@ -34,14 +34,14 @@
                  BorderThickness="3" BorderBrush="#33000000" Grid.ColumnSpan="2" VirtualizingPanel.IsVirtualizing='True' VirtualizingPanel.IsVirtualizingWhenGrouping='True' VirtualizingPanel.ScrollUnit='Pixel'>
             <ListBox.ItemsPanel>
                 <ItemsPanelTemplate>
-                    <controls:VirtualizingWrapPanel IsItemsHost="True" />
+                    <WrapPanel />
                 </ItemsPanelTemplate>
             </ListBox.ItemsPanel>
             <ListBox.GroupStyle>
                 <GroupStyle ContainerStyle="{StaticResource ItemsGroupItem}">
                     <GroupStyle.Panel>
                         <ItemsPanelTemplate>
-                            <VirtualizingStackPanel Orientation="Vertical" />
+                            <WrapPanel />
                         </ItemsPanelTemplate>
                     </GroupStyle.Panel>
                 </GroupStyle>
@@ -58,7 +58,7 @@
                         </Grid.ToolTip>
                         <Grid>
                             <!--<Image Source="{Binding image}"  HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Margin="5"></Image>-->
-                            <Image Source="{Binding shortName, Converter={StaticResource RelativeUriFromShortnameConverter}, ConverterParameter='Assets\\RustItems', IsAsync=true}"  HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Margin="5"></Image>
+                            <Image Source="{Binding Source}"  HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Margin="5"></Image>
                             <TextBlock Margin="0,0,5,5" Visibility="Hidden" Text="{Binding displayName}" Foreground="White" FontWeight="Bold" FontSize="11"
                                        TextWrapping="Wrap" TextAlignment="Center" VerticalAlignment="Bottom" HorizontalAlignment="Right"></TextBlock>
                         </Grid>


### PR DESCRIPTION
new RustItem.Source Property with resized Image
//F:\\Games\\steamapps\\common\\Rust\\Bundles\\items\\ my current Path to gamefolder

shortname -> BitmapSource cache could be added to reuse not skinned images